### PR TITLE
Limit tinycolor2 version to 1.1.2

### DIFF
--- a/server/imageServer/package.json
+++ b/server/imageServer/package.json
@@ -6,7 +6,7 @@
   "main": "imageserver.js",
   "dependencies": {
     "canvas": "*",
-    "tinycolor2": "*",
+    "tinycolor2": "1.1.2",
     "graceful-fs": "*"
   },
   "devDependencies": {},


### PR DESCRIPTION
later versions change toHex8's output [here](https://github.com/bgrins/TinyColor/commit/32a4be15e3cab062eb0fd51e814487b4b20323c0#diff-04c6e90faac2675aa89e2176d2eec7d8R242)