### PR TITLE
fix the 'block' drawing type bug.

### DIFF
--- a/src/server/imageServer/scripts/TiledCanvas.js
+++ b/src/server/imageServer/scripts/TiledCanvas.js
@@ -82,7 +82,7 @@ TiledCanvas.prototype.drawFunctions = {
             return;
         }
 
-        context.fillStyle = drawing.color;
+        context.fillStyle = drawing.color.toRgbString();
         context.fillRect(drawing.x, drawing.y, drawing.size, drawing.size);
 
         if (tiledCanvas) {


### PR DESCRIPTION
The 'block' drawing is working properly in the user side (paint.min.js), getting the color correctly from the object:
(example)
anondraw.collab.paint.addUserDrawing({
    type: "block",
    x: 680000,
    y: 680000,
    size: 50,
    color: anondraw.collab.paint.current_color
});
The problem is the server side (TiledCanvas.js) needs this information as a string for the context.fillStyle.
As a result, it fails to get the color and puts black replacing the missing color.
So, to fix that, line 85 was changed from context.fillStyle = drawing.color; to context.fillStyle = drawing.color.toRgbString();