### PR TITLE
Let the website less annoying for new users

### DIFF
--- a/src/client/src/scripts/DrawTogether.js
+++ b/src/client/src/scripts/DrawTogether.js
@@ -176,7 +176,7 @@ DrawTogether.prototype.defaultSettings = {
 DrawTogether.prototype.defaultUserSettings = [{
 	title: "Mute chat",
 	type: "boolean",
-	value: false
+	value: true
 }, {
 	title: "Show tips",
 	type: "boolean",


### PR DESCRIPTION
'mute chat' as default to avoid most of people leaving it in under a minute.