### PR TITLE
Fix node version for realtime server dockerfile

### DIFF
--- a/src/server/realTime/Dockerfile
+++ b/src/server/realTime/Dockerfile
@@ -1,5 +1,10 @@
 # Base inmage
-FROM node:current AS build
+FROM node:18 AS build
+# With 'node:current', the build process for the binaries of 'node-canvas' fails.
+# Currently there doesn't seem to be binaries for this version of Linux + Node v20 + node-canvas.
+# The latest release of node-canvas [v2.11.2](https://github.com/Automattic/node-canvas/releases/tag/v2.11.2)
+#   should work, but it doesn't. The binaries can't be built when running the build process in `yarn install`.
+# We will probably get a proper binary for Node v20 later, so for now we'll fallback to Node v18.
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Running `docker-compose up --build -d` fails. Apparently the problem is in `src\server\realTime\Dockerfile`,  when Docker runs the build process with `yarn install`. The problem is that we are using `node:current`.

```
...
3.009 ➤ YN0000: │ canvas@npm:2.7.0 STDERR node-pre-gyp WARN Pre-built binaries not found for canvas@2.7.0 and node@20.5.1 (node-v115 ABI, glibc) (falling back to source compile with node-gyp)      
3.009 ➤ YN0000: │ canvas@npm:2.7.0 STDERR node-pre-gyp http 404 status code downloading tarball https://github.com/Automattic/node-canvas/releases/download/v2.7.0/canvas-v2.7.0-node-v115-linux-glibc-x64.tar.gz
...
```

The building of the binaries for `node-canvas` fails, because there don't seem to be binaries for the combination of Node v20 + Linux + `node-canvas`).

The latest release of `node-canvas` [v2.11.2](https://github.com/Automattic/node-canvas/releases/tag/v2.11.2) should work, but idk the dependency building doesn't work.

We will probably get a proper binary for Node v20 later, so for now we'll fallback to Node v18.


